### PR TITLE
Use [?] marker for out-of-range chars

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,5 +69,5 @@ pub fn unidecode(s: &str) -> String {
 /// ```
 #[inline]
 pub fn unidecode_char(ch: char) -> &'static str {
-    MAPPING.get(ch as usize).map(|&s| s).unwrap_or("")
+    MAPPING.get(ch as usize).map(|&s| s).unwrap_or("[?]")
 }


### PR DESCRIPTION
The empty string "" translation is a bit unfortunate as it loses information. Although it cannot always be easily avoided, in the case of out-of-range characters it seems easy to do so.